### PR TITLE
Precompute depth array in mutation loop (O(n²) → O(n))

### DIFF
--- a/src/M_E_GA/engine/mutation_manager.py
+++ b/src/M_E_GA/engine/mutation_manager.py
@@ -60,15 +60,18 @@ class MutationManager:
 
         i = 0
         detailed_logs = []
-        
+
         # Get codons once
         start_codon = self.ga.encoding_manager.reverse_encodings['Start']
         end_codon = self.ga.encoding_manager.reverse_encodings['End']
         delimiter_codons = {start_codon, end_codon}
 
+        # Pre-compute depth at each position in O(n) instead of O(n) per position
+        depths = self._compute_depths(organism, start_codon, end_codon)
+
         while i < len(organism):
             gene = organism[i]
-            depth = self.calculate_depth(organism, i)
+            depth = depths[i]
             
             is_delimiter = gene in delimiter_codons
             
@@ -142,6 +145,7 @@ class MutationManager:
                         organism, i, mutation_event = self.apply_mutation(
                             organism, i, mutation_type_to_apply, generation
                         )
+                        depths = self._compute_depths(organism, start_codon, end_codon)
 
                         if log_enhanced and mutation_event:
                             detailed_logs.append({
@@ -200,6 +204,18 @@ class MutationManager:
             # No recognized mutation / safety fallback
             index += 1
             return organism, index, None
+
+    @staticmethod
+    def _compute_depths(organism, start_codon, end_codon):
+        depths = [0] * len(organism)
+        depth = 0
+        for i, codon in enumerate(organism):
+            depths[i] = depth
+            if codon == start_codon:
+                depth += 1
+            elif codon == end_codon and depth > 0:
+                depth -= 1
+        return depths
 
     def calculate_depth(self, organism, index):
         """

--- a/tests/test_depth_performance.py
+++ b/tests/test_depth_performance.py
@@ -1,0 +1,109 @@
+"""
+Tests for the _compute_depths optimization: correctness and performance.
+"""
+
+import random
+import time
+import unittest
+
+from src.M_E_GA import M_E_GA_Base
+from src.M_E_GA.engine.mutation_manager import MutationManager
+
+
+class TestComputeDepthsCorrectness(unittest.TestCase):
+
+    def setUp(self):
+        random.seed(42)
+        self.ga = M_E_GA_Base(
+            genes=['A', 'B', 'C'],
+            fitness_function=lambda org, ga: 0.0,
+            population_size=2,
+            max_individual_length=10,
+            logging=False,
+            experiment_name="TestDepths"
+        )
+        self.mm = self.ga.mutation_manager
+        self.start = self.ga.encoding_manager.reverse_encodings['Start']
+        self.end = self.ga.encoding_manager.reverse_encodings['End']
+
+    def test_matches_original_no_delimiters(self):
+        a = self.ga.encoding_manager.reverse_encodings['A']
+        b = self.ga.encoding_manager.reverse_encodings['B']
+        organism = [a, b, a, b, a]
+        depths = MutationManager._compute_depths(organism, self.start, self.end)
+        for i in range(len(organism)):
+            self.assertEqual(depths[i], self.mm.calculate_depth(organism, i))
+
+    def test_matches_original_with_delimiters(self):
+        a = self.ga.encoding_manager.reverse_encodings['A']
+        organism = [self.start, a, a, self.end, a, self.start, a, self.end]
+        depths = MutationManager._compute_depths(organism, self.start, self.end)
+        for i in range(len(organism)):
+            self.assertEqual(depths[i], self.mm.calculate_depth(organism, i))
+
+    def test_matches_original_nested(self):
+        a = self.ga.encoding_manager.reverse_encodings['A']
+        organism = [self.start, a, self.start, a, self.end, a, self.end]
+        depths = MutationManager._compute_depths(organism, self.start, self.end)
+        for i in range(len(organism)):
+            self.assertEqual(depths[i], self.mm.calculate_depth(organism, i))
+
+    def test_matches_original_unmatched(self):
+        a = self.ga.encoding_manager.reverse_encodings['A']
+        organism = [self.end, a, self.start, a, self.end, self.end, a]
+        depths = MutationManager._compute_depths(organism, self.start, self.end)
+        for i in range(len(organism)):
+            self.assertEqual(depths[i], self.mm.calculate_depth(organism, i))
+
+    def test_matches_original_random_organisms(self):
+        population = self.ga.initialize_population()
+        for organism in population:
+            depths = MutationManager._compute_depths(organism, self.start, self.end)
+            for i in range(len(organism)):
+                self.assertEqual(depths[i], self.mm.calculate_depth(organism, i))
+
+    def test_empty_organism(self):
+        self.assertEqual(MutationManager._compute_depths([], self.start, self.end), [])
+
+
+class TestComputeDepthsPerformance(unittest.TestCase):
+
+    def setUp(self):
+        random.seed(42)
+        self.ga = M_E_GA_Base(
+            genes=['A', 'B', 'C'],
+            fitness_function=lambda org, ga: 0.0,
+            population_size=2,
+            max_individual_length=10,
+            logging=False,
+            experiment_name="TestDepthsPerf"
+        )
+        self.mm = self.ga.mutation_manager
+        self.start = self.ga.encoding_manager.reverse_encodings['Start']
+        self.end = self.ga.encoding_manager.reverse_encodings['End']
+
+    def test_precompute_is_faster(self):
+        a = self.ga.encoding_manager.reverse_encodings['A']
+        codons = [a, self.start, a, self.end]
+        organism = codons * 250  # length 1000
+
+        # Old approach: call calculate_depth(organism, i) for every i
+        t0 = time.perf_counter()
+        for _ in range(10):
+            for i in range(len(organism)):
+                self.mm.calculate_depth(organism, i)
+        old_time = time.perf_counter() - t0
+
+        # New approach: single _compute_depths call
+        t0 = time.perf_counter()
+        for _ in range(10):
+            MutationManager._compute_depths(organism, self.start, self.end)
+        new_time = time.perf_counter() - t0
+
+        speedup = old_time / new_time
+        print(f"\nOld (per-index): {old_time:.4f}s | New (precompute): {new_time:.4f}s | Speedup: {speedup:.1f}x")
+        self.assertGreater(speedup, 10, f"Expected >10x speedup, got {speedup:.1f}x")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
 
`calculate_depth()` was called at every position in the mutation loop, scanning from index 0 each time, making it O(n²) per organism. Added `_compute_depths()` to pre-compute the full depth array in a single O(n) pass, recomputed after any mutation modifies the organism. No behavioral changes.

> Note: I just happened to notice this while browsing the codebase, so I put a quick PR together. I'm not familiar enough with the codebase to really know if this matters or how to properly verify.

## Benchmark

Organism length 1000, 10 iterations:

| Method | Time |
|---|---|
| Old (per-index) | 0.1261s |
| New (precompute) | 0.0003s |
| Speedup | 441x |

## Testing

- 6 correctness tests verify `_compute_depths` matches `calculate_depth` for all edge cases (no delimiters, nested, unmatched, random organisms, empty)
- 1 performance benchmark asserts >10x speedup
- All 22 pre-existing passing tests unchanged
```python
python -m pytest tests/ -v
```